### PR TITLE
Replaced sanitize_title with sanitize_text_field

### DIFF
--- a/qtranslate-slug.php
+++ b/qtranslate-slug.php
@@ -1470,7 +1470,7 @@ class QtranslateSlug {
 
 		if ( 'slug' == $field ) {
 			$field = 'm.meta_key = \''.$this->get_meta_key().'\' AND m.meta_value';
-			$value = sanitize_title($value);
+			$value = sanitize_text_field($value);
 			if ( empty($value) )
 				return false;
 		} else if ( 'name' == $field ) {
@@ -1713,7 +1713,7 @@ class QtranslateSlug {
 		
 		$slug = trim($slug);
 			
-		$slug = (empty($slug)) ? sanitize_title($name) : sanitize_title($slug);
+		$slug = (empty($slug)) ? sanitize_text_field($name) : sanitize_text_field($slug);
 		
 		
 		
@@ -1923,7 +1923,7 @@ class QtranslateSlug {
 		
 		$slug = trim($slug);
 			
-		$slug = (empty($slug)) ? sanitize_title($name) : sanitize_title($slug);
+		$slug = (empty($slug)) ? sanitize_text_field($name) : sanitize_text_field($slug);
 		
 		return htmlspecialchars( $slug , ENT_QUOTES );
 	}


### PR DESCRIPTION
sanitize_title messes up some strings with foreign encoding/characters, for example russian word 

швейцария (france) --> %d1%84%d1%80%d0%b0%d0%bd%d1%86%d0%b8%d1%8f
