### PR TITLE
Php 5.4 compatibility

### DIFF
--- a/qtranslate-slug.php
+++ b/qtranslate-slug.php
@@ -1314,7 +1314,11 @@ class QtranslateSlug {
 		if ( !$id )
 			$id = (int) $post->ID;
 		else
+			if(phpversion() >= 5.4) {
+			$current_post = get_post($id);
+			} else {
 			$current_post = &get_post($id);
+			}
 
 		$draft_or_pending = in_array( $current_post->post_status, array( 'draft', 'pending', 'auto-draft' ) );
 


### PR DESCRIPTION
Removed the ampersand for php 5.4 and greater. Creates a notice error and fills php error logs. Added compatibility for older versions of php (which shouldn't be used)
