### PR TITLE
Fixed a small bug that caused an strict standards warning

### DIFF
--- a/qtranslate-slug.php
+++ b/qtranslate-slug.php
@@ -1314,7 +1314,7 @@ class QtranslateSlug {
 		if ( !$id )
 			$id = (int) $post->ID;
 		else
-			$current_post = &get_post($id);
+			$current_post = get_post($id);
 
 		$draft_or_pending = in_array( $current_post->post_status, array( 'draft', 'pending', 'auto-draft' ) );
 


### PR DESCRIPTION
The get_post() function called on QtranslateSlug::_get_page_link() caused an PHP Strict Standards warning.
