### PR TITLE
added search query parameter for filter request

### DIFF
--- a/qtranslate-slug.php
+++ b/qtranslate-slug.php
@@ -884,6 +884,14 @@ class QtranslateSlug {
 			
 		endif;
 		
+	    // -> search
+	    if(isset($query['s'])):
+
+		  $id=$query['s'];
+		  $function="get_search_link";
+	  
+	    endif;	  
+		
 		if ( isset($function) ):
 				
 		// parse all languages links


### PR DESCRIPTION
This is a bug fix. Without this fix, visitor performed a search and the language menu of
all the languages listed contained the same language value in their URL.

For example if current language is EN and we have two languages EN,DE, after the search, the language menu had the following URL

For EN -> www.domain.com/en/...
For DE -> www.domain.com/en/...

So the solution I came up with was to use get_search_link WordPress function that retrieves permalink for search.

This is my first Pull Request and I'm still new to the Git and GitHub, so I apologize if I missed something in the comments.
