### PR TITLE
Strict standard advise prevented

### DIFF
--- a/includes/class-qtranslate-slug.php
+++ b/includes/class-qtranslate-slug.php
@@ -944,8 +944,9 @@ class QtranslateSlug {
         $slug = rawurlencode( urldecode( $slug ) );
         $slug = str_replace('%2F', '/', $slug);
         $slug = str_replace('%20', ' ', $slug);
-            
-        return array_pop( explode('/', $slug) );
+        $exploded_slug = explode('/', $slug);
+
+        return array_pop( $exploded_slug );
     }
     
     


### PR DESCRIPTION
Solved the strict standard advise:

Strict Standards: Only variables should be passed by reference in
/…/wp-content/plugins/qtranslate-slug/qtranslate-slug.php on line 1000
