### PR TITLE
Compatibility for qTranslate-X

### DIFF
--- a/includes/class-qtranslate-slug.php
+++ b/includes/class-qtranslate-slug.php
@@ -194,7 +194,7 @@ class QtranslateSlug {
      * @since tbd
      */
     private function plugin_prefix(){
-        if ('' === $this->$plugin_prefix){
+        if ('' === $this->plugin_prefix){
             if (is_plugin_active('qtranslate-x/qtranslate.php')){
                 $this->plugin_prefix = 'qtranxf_';
             } else {


### PR DESCRIPTION
This pull request adds compatibility with the qTranslate-X plugin, while keeping the functionality for qTranslate and mqTranslate. This was done by creating a new private function that will return the correct plugin prefix - `qtrans_` or `qtranxf_`, depending on what is installed. If both qTranslate-X and qTranslate are installed, the qTranslate-X functions will be used.
The implementation was done by replacing the hard-coded function calls to `qtrans_xyz()` with dynamic calls using `call_user_func()`. Also, wordpress action and filter hooks were replaced. I did not change any css classes since this might break the styling in some templates.
Please let me know if you'd like to take this in, or if you want to stay focused on qTranslate and mqTranslate, in which case I'd like to maintain this as a separate project for users of qTranslate-X.
