### PR TITLE
Bug fix in "Slug (%s)" string translation

### DIFF
--- a/includes/class-qtranslate-slug.php
+++ b/includes/class-qtranslate-slug.php
@@ -2000,7 +2000,7 @@ class QtranslateSlug {
                 $value = ( $slug ) ? htmlspecialchars( $slug , ENT_QUOTES ) : '';
             
                 echo "<tr class=\"form-field form-required\">" . PHP_EOL;
-                echo "<th scope=\"row\" valig=\"top\"><label for=\"qts_term_{$lang}_slug\">Slug (".__($q_config['language_name'][$lang], 'qtranslate').")</label></th>" . PHP_EOL;
+                echo "<th scope=\"row\" valig=\"top\"><label for=\"qts_term_{$lang}_slug\">".sprintf( __('Slug (%s)', 'qts'), $q_config['language_name'][$lang] )."</label></th>" . PHP_EOL;
                 echo "<td><input type=\"text\" name=\"qts_{$lang}_slug\" value=\"$value\" /></td></tr>" . PHP_EOL;
             
             }
@@ -2020,7 +2020,7 @@ class QtranslateSlug {
                 $value = ( $slug ) ? htmlspecialchars( $slug , ENT_QUOTES ) : '';
             
 
-                echo "<label for=\"qts_{$lang}_slug\">Slug (".__($q_config['language_name'][$lang], 'qtranslate').")</label>" . PHP_EOL;
+                echo "<label for=\"qts_{$lang}_slug\">".sprintf( __('Slug (%s)', 'qts'), $q_config['language_name'][$lang] )."</label>" . PHP_EOL;
                 echo "<input type=\"text\" name=\"qts_term_{$lang}_slug\" value=\"$value\" aria-required=\"true\">" . PHP_EOL;
                 
                 echo '</div>';


### PR DESCRIPTION
String "Slug (%s)" wasn't being translated because it was picking just "Slug (" concatenated with LANG and another ")"
Changed it to code below as it was correctly used in qtranslate-slug-settings-options.php:
sprintf( __('Slug (%s)', 'qts'), $q_config['language_name'][$lang] )

It's now correctly referenced for translation both in New and Edit category/tag pages.
